### PR TITLE
jquery.cookieが廃止されていたのでjs-cookie 2.2.1に移行

### DIFF
--- a/PopupIE.js
+++ b/PopupIE.js
@@ -73,10 +73,10 @@ $(function() {
 
     // 初回閲覧時のみ表示するスクリプト
     $(".overlay").show();
-    $.cookie('btnFlg') == 'on' ? $('.overlay').hide() : $('.overlay').show();
+    Cookies.get('btnFlg') == 'on' ? $('.overlay').hide() : $('.overlay').show();
     $('.alert-box button').click(function(){
       $('.overlay').fadeOut();
-      $.cookie('btnFlg', 'on', { expires: 3,path: '/' }); //cookieの保存
+      Cookies.set('btnFlg', 'on', { expires: 3,path: '/' }); //cookieの保存
     });
   }
 });

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ IE から Edge, Chrome への移行を促します．
 
 使用する際は，Cookieを制御するライブラリ  
 
-```<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js"></script>```  
+```<script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.2.1/js.cookie.min.js"></script>```  
 
 をPopupIE.jsの前に読み込んで下さい．

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Document</title>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.2.1/js.cookie.min.js"></script>
   <script type="text/javascript" src="popupIE.js"></script>
 </head>
 <body>


### PR DESCRIPTION
[jquery.cookieが廃止](https://github.com/carhartl/jquery-cookie)されていたので、[代替として提案](https://github.com/carhartl/jquery-cookie#important)されていた[js-cookie](https://github.com/js-cookie/js-cookie)に移行しました。
[完全な互換性を持つのは1.x系](https://github.com/js-cookie/js-cookie/tree/v1.5.1#migrating-from-jquery-cookie)ですが、開発の活発さと互換性を鑑みて2.2.1を移行先としました。